### PR TITLE
pull out docs from typical ci build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,22 @@ on:
     branches: [main]
 
 jobs:
+  build_docs: 
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: 
+          node-version: 20
+      - run: npm ci
+      - name: Build Documentation Site
+        run: npm run docs:build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./apps/docs/out
+
   build_and_test:
     name: "Build and Test"
     runs-on: ubuntu-latest
@@ -41,12 +57,6 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
-      - name: Build Documentation Site
-        run: npm run docs:build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./apps/docs/out
 
 
   publish:
@@ -93,7 +103,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build_and_test
+    needs: build_docs
     permissions: 
       contents: read
       pages: write


### PR DESCRIPTION
- Docs build is separate as its not dependant on vite-plugin-posthog